### PR TITLE
:sparkles: - Add support for fully qualified types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Rust Diesel -> ReasonML 
 
 ## Todo
-- [x] - Add config with 'ignore' to ignore record keys for a certain type / module
-- [ ] - Update config to include specified ignores (ie. x.y)
-- [ ] - Further decouple parser / printer (flow should be `read, parse, print`)
+- [ ] - use `Data.Text` over `[Char]`
 
 ## Before First Run
 Pre-requisites: 
@@ -33,15 +31,14 @@ types:
     - Array->array
     - Nullable->option
 hiding:
-  configured:
-    - key:
-      - values
-    - key2:
-      - values
   tables: 
     - hide_me 
   keys: 
     - hidden_id
+  qualified:
+    qualified_hide:
+    - qualified_field
+    - another_qualified_field
 ```
 
 `example-schema.rs`
@@ -51,6 +48,23 @@ table! {
 
     hide_me (hide_me_id) {
         hide_me_id -> Uuid,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+
+    qualified_shown (test_id) {
+        qualified_field -> Text,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+
+    qualified_hide (test_id) {
+        qualified_field -> Text,
+        another_qualified_field -> Text,
     }
 }
 
@@ -75,6 +89,19 @@ type uuid = string;
 
 // module HideMe { };
 
+module QualifiedShown {
+	type t = {
+		qualifiedField: string
+	};
+
+};
+module QualifiedHide {
+	type t = {
+		// qualifiedField: string,
+		// anotherQualifiedField: string
+	};
+
+};
 module Test {
 	type t = {
 		testId: uuid,

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,6 +12,4 @@ main = do
 
   configuration <- makeConfig configFile
   contents <- readFile schemaFile
-  putStrLn $ printSchema configuration $ parseSchema contents
-
---putStrLn $ printTypeAliases (aliases configuration) <> parseSchema configuration contents
+  putStrLn $ printTypeAliases (aliases configuration) <> (printSchema configuration $ parseSchema contents)

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -11,12 +11,11 @@ types:
     - Array->array
     - Nullable->option
 hiding:
-  configured:
-    - key:
-      - values
-    - key2:
-      - values
   tables: 
     - hide_me 
   keys: 
     - hidden_id
+  qualified:
+    qualified_hide:
+    - qualified_field
+    - another_qualified_field

--- a/example-schema.rs
+++ b/example-schema.rs
@@ -9,6 +9,23 @@ table! {
 table! {
     use diesel::sql_types::*;
 
+    qualified_shown (test_id) {
+        qualified_field -> Text,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+
+    qualified_hide (test_id) {
+        qualified_field -> Text,
+        another_qualified_field -> Text,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+
     test (test_id) {
         test_id -> Uuid,
         hidden_id -> Uuid,

--- a/src/ConfigurationParser.hs
+++ b/src/ConfigurationParser.hs
@@ -7,27 +7,33 @@ import Data.List.Split (splitOn)
 import qualified Data.Map as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
-import Data.Yaml.Config (load, lookupDefault, subconfig)
-import Types
+import qualified Data.Text as T
+import Data.Yaml.Config (Config, keys, load, lookup, lookupDefault, subconfig)
+import qualified Types as T
 
 parseTypeMapConfiguration :: String -> Maybe (String, String)
 parseTypeMapConfiguration xs = case splitOn "->" xs of
   [x, y] -> Just (x, y) --TODO - trim whitespace
   _ -> Nothing
 
-toTypeMap :: [String] -> Mapping
+toTypeMap :: [String] -> T.Mapping
 toTypeMap = M.fromList . mapMaybe parseTypeMapConfiguration
 
-makeConfig :: String -> IO Configuration
+toQualified :: Config -> T.HiddenQualified
+toQualified xs = M.fromList $ map (\k -> (T.unpack k, S.fromList $ lookupDefault k [] xs)) (keys xs)
+
+makeConfig :: String -> IO T.Configuration
 makeConfig path = do
   config <- load path
   types <- subconfig "types" config
   hiding <- subconfig "hiding" config
+  qualified <- subconfig "qualified" hiding
 
   pure $
-    Configuration
+    T.Configuration
       (toTypeMap $ lookupDefault "aliases" [] types)
       (toTypeMap $ lookupDefault "base" [] types)
       (toTypeMap $ lookupDefault "nested" [] types)
       (S.fromList $ lookupDefault "tables" [] hiding)
       (S.fromList $ lookupDefault "keys" [] hiding)
+      (toQualified qualified)

--- a/src/SchemaParser.hs
+++ b/src/SchemaParser.hs
@@ -1,7 +1,6 @@
-module SchemaParser (parseSchema) where
+module SchemaParser (parseTypeContainer, parseSchema) where
 
 import Data.Set (member)
-import SchemaPrinter
 import Text.Parsec
 import Type.Reflection.Unsafe
 import Types

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -3,24 +3,33 @@ module Types where
 import qualified Data.Map as M
 import qualified Data.Set as S
 
+------------------
+-- Schema Types
+------------------
 type TypePair = (String, String)
 
 type Table = (String, [TypePair])
 
 type Schema = [Table]
 
+data Visibility a = Visible a | Hidden
+     deriving (Eq, Ord)
+------------------
+-- Configuration Types
+------------------
+
 type Mapping = M.Map String String
 
 type Hidden = S.Set String
 
-data Visibility a = Visible a | Hidden
-     deriving (Eq, Ord)
+type HiddenQualified = M.Map String (S.Set String)
 
 data Configuration = Configuration
   { aliases :: Mapping,
     base :: Mapping,
     nested :: Mapping,
     tables :: Hidden,
-    keys :: Hidden
+    keys :: Hidden,
+    qualified :: HiddenQualified
   }
   deriving (Show)


### PR DESCRIPTION
This PR adds the ability to hide qualified fields from the output;

```yaml
  qualified:
    qualified_hide:
    - qualified_field
    - another_qualified_field
```

So for instance if one would want to hide the password from a user;

```yaml
  qualified:
    user:
    - password
```